### PR TITLE
refactor: share groupReposByLanguage

### DIFF
--- a/docs/js/components/tabs.js
+++ b/docs/js/components/tabs.js
@@ -1,6 +1,7 @@
 import { renderRepoCard } from './carousel.js';
 import { fetchOrgRepos, fetchUserProfile } from '../api/github.js';
 import { showProjectDetails } from './modal.js';
+import { groupReposByLanguage } from '../utils/group.js';
 
 // SVG icons for folder states
 const FOLDER_ICONS = {
@@ -12,18 +13,6 @@ const FOLDER_ICONS = {
   </svg>`
 };
 
-// Group repos by language
-function groupReposByLanguage(repos) {
-  const groups = {};
-  repos.forEach(repo => {
-    const lang = repo.language || 'Unknown';
-    if (!groups[lang]) {
-      groups[lang] = [];
-    }
-    groups[lang].push(repo);
-  });
-  return groups;
-}
 
 function highlightSelectedFolder(li, folderList) {
   if (!li) return;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -3,6 +3,7 @@ import { updateFeaturedProjects, initCarousel } from './components/carousel.js';
 import { renderFolderList, initTabSwitching, displayOrgRepos } from './components/tabs.js';
 import { initUserSearch, initRepoSearch } from './utils/search.js';
 import { initThemeManager } from './utils/theme.js';
+import { groupReposByLanguage } from './utils/group.js';
 import { createProjectModal, showProjectDetails } from './components/modal.js';
 import cache from './state/cache.js';
 
@@ -141,18 +142,6 @@ async function initRepos() {
   }
 }
 
-// Group repos by language
-function groupReposByLanguage(repos) {
-  const groups = {};
-  repos.forEach(repo => {
-    const lang = repo.language || 'Unknown';
-    if (!groups[lang]) {
-      groups[lang] = [];
-    }
-    groups[lang].push(repo);
-  });
-  return groups;
-}
 
 // Initialize the application
 function init() {

--- a/docs/js/utils/group.js
+++ b/docs/js/utils/group.js
@@ -1,0 +1,11 @@
+export function groupReposByLanguage(repos) {
+  const groups = {};
+  repos.forEach(repo => {
+    const lang = repo.language || 'Unknown';
+    if (!groups[lang]) {
+      groups[lang] = [];
+    }
+    groups[lang].push(repo);
+  });
+  return groups;
+}


### PR DESCRIPTION
## Summary
- consolidate repo grouping logic into `utils/group.js`
- use shared helper in `main.js` and `tabs.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684edd61a974832da2346e658c3dd7ff