### PR TITLE
Fix CSS transition property for folder icon

### DIFF
--- a/docs/styles/styles.css
+++ b/docs/styles/styles.css
@@ -720,7 +720,7 @@ footer {
 }
 
 .folder-svg path {
-  transition: d 0.3s ease;
+  transition: fill 0.3s ease;
 }
 
 li.selected .folder-svg {


### PR DESCRIPTION
## Summary
- use `transition: fill` for `.folder-svg path`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684edf34d018832d95edb2671e33f8ee