### PR TITLE
Fix cache clearing order

### DIFF
--- a/docs/js/state/cache.js
+++ b/docs/js/state/cache.js
@@ -61,7 +61,7 @@ class Cache {
   clearAll() {
     this.cache.clear();
     // Clear only our cache items from localStorage
-    for (let i = 0; i < localStorage.length; i++) {
+    for (let i = localStorage.length - 1; i >= 0; i--) {
       const key = localStorage.key(i);
       if (key.startsWith('cache_')) {
         localStorage.removeItem(key);


### PR DESCRIPTION
## Summary
- prevent skipping cached keys by iterating localStorage backwards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684edf35ddd0832d8025ec92ec788813